### PR TITLE
fix: Await session closure on shutdown

### DIFF
--- a/base/generic-webdriver-server.js
+++ b/base/generic-webdriver-server.js
@@ -478,7 +478,7 @@ class GenericSingleSessionWebDriverServer extends GenericWebDriverServer {
   /** @override */
   async shutdown() {
     if (this.sessionId_) {
-      this.closeSession(this.sessionId_);
+      await this.closeSession(this.sessionId_);
     }
 
     await this.shutdownSingleSession();


### PR DESCRIPTION
When shutting down the server, don't just initiate session closure.  Actually wait for the session to close.

Issue #44