### PR TITLE
fix(xbox): Fix several reliability issues

### DIFF
--- a/backends/xboxone/package-lock.json
+++ b/backends/xboxone/package-lock.json
@@ -14,7 +14,7 @@
       "dependencies": {
         "form-data": "^4.0.0",
         "fs-extra": "^9.1.0",
-        "generic-webdriver-server": "^1.1.3",
+        "generic-webdriver-server": "^1.1.4",
         "tmp-promise": "^3.0.2"
       },
       "bin": {
@@ -24,7 +24,7 @@
     },
     "../../base": {
       "name": "generic-webdriver-server",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "express": "^4.17.3",

--- a/backends/xboxone/package.json
+++ b/backends/xboxone/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "form-data": "^4.0.0",
     "fs-extra": "^9.1.0",
-    "generic-webdriver-server": "^1.1.3",
+    "generic-webdriver-server": "^1.1.4",
     "tmp-promise": "^3.0.2"
   },
   "workspaces": [

--- a/backends/xboxone/xbox-one-utils.js
+++ b/backends/xboxone/xbox-one-utils.js
@@ -34,6 +34,17 @@ const defaultPort = 11443;  // For the Xbox One Device Portal
 const packageFolderName = 'XboxOneWebDriverServer_1.0.0.0_Test';
 const packageBundleName = 'XboxOneWebDriverServer_1.0.0.0_x64.msixbundle';
 
+// Sometimes, a launch will fail with ERROR_INSTALL_REGISTRATION_FAILURE.  This
+// is especially true when launching tests over and over in a loop.  It is
+// unclear what is causing it, but the situation usually resolves itself after
+// a few minutes.
+const launchRetryDelay = 30;  // seconds
+const numLaunchRetries = 10;
+
+// A Microsoft error code and its official name.
+const ERROR_INSTALL_REGISTRATION_FAILURE = -2147009290;
+
+
 // Main API reference docs:
 // https://docs.microsoft.com/en-us/windows/uwp/debug-test-perf/device-portal-api-core
 // https://docs.microsoft.com/en-us/windows/uwp/xbox-apps/reference
@@ -72,7 +83,7 @@ async function loadOnXboxOne(flags, log, url) {
       await installApp(
           tmpDir.path, flags.hostname, flags.username, flags.password);
       log.info('Launching app');
-      await launchApp(flags.hostname, flags.username, flags.password);
+      await launchApp(log, flags.hostname, flags.username, flags.password);
     } finally {
       // Remove our temporary directory.
       tmpDir.cleanup();
@@ -186,16 +197,43 @@ async function installApp(tempPath, xboxOneAddress, username, password) {
 /**
  * Launch the application on the specified Xbox One.
  *
+ * @param {Console} log A Console-like interface for logging.  Can be "console".
  * @param {string} xboxOneAddress The IP or hostname of the Xbox One device.
  * @param {string} username The username to authenticate to the Device Portal.
  * @param {string} password The password to authenticate to the Device Portal.
  * @return {!Promise}
  */
-async function launchApp(xboxOneAddress, username, password) {
-  // https://docs.microsoft.com/en-us/windows/uwp/debug-test-perf/device-portal-api-core#start-a-modern-app
-  await httpRequestHelper(
-      xboxOneAddress, username, password,
-      'POST', `api/taskmanager/app?appid=${appIdBase64}`);
+async function launchApp(log, xboxOneAddress, username, password) {
+  for (let i = 0; i < numLaunchRetries; ++i) {
+    try {
+      // https://docs.microsoft.com/en-us/windows/uwp/debug-test-perf/device-portal-api-core#start-a-modern-app
+      // Return right away on success.
+      return await httpRequestHelper(
+          xboxOneAddress, username, password,
+          'POST', `api/taskmanager/app?appid=${appIdBase64}`);
+    } catch (error) {
+      let xboxError = {};
+      try {
+        xboxError = JSON.parse(error.body);
+      } catch (jsonError) {} // ignored
+
+      if (xboxError.ErrorCode == ERROR_INSTALL_REGISTRATION_FAILURE) {
+        log.error('Launch failure (ERROR_INSTALL_REGISTRATION_FAILURE).');
+        if (i == numLaunchRetries - 1) {
+          // No more retries.
+          throw error;
+        }
+
+        log.error('Retrying after delay.');
+        await delay(launchRetryDelay);
+
+        log.error('Retrying launch.');
+      } else {
+        // A different error than the one we handle automatically.
+        throw error;
+      }
+    }
+  }
 }
 
 /**
@@ -302,6 +340,16 @@ function httpRequestHelper(
       req.end();
     }
   });
+}
+
+/**
+ * Delay for a fixed number of seconds.
+ *
+ * @param {number} seconds
+ * @return {!Promise}
+ */
+function delay(seconds) {
+  return new Promise((resolve) => setTimeout(resolve, seconds * 1000));
 }
 
 /**

--- a/backends/xboxone/xbox-one-utils.js
+++ b/backends/xboxone/xbox-one-utils.js
@@ -220,16 +220,16 @@ async function launchApp(log, xboxOneAddress, username, password) {
       }
 
       if (xboxError.ErrorCode == ERROR_INSTALL_REGISTRATION_FAILURE) {
-        log.error('Launch failure (ERROR_INSTALL_REGISTRATION_FAILURE).');
+        log.debug('Launch failure (ERROR_INSTALL_REGISTRATION_FAILURE).');
         if (i == numLaunchRetries - 1) {
           // No more retries.
           throw error;
         }
 
-        log.error('Retrying after delay.');
+        log.debug('Retrying after delay.');
         await delay(launchRetryDelay);
 
-        log.error('Retrying launch.');
+        log.debug('Retrying launch.');
       } else {
         // A different error than the one we handle automatically.
         throw error;

--- a/backends/xboxone/xbox-one-utils.js
+++ b/backends/xboxone/xbox-one-utils.js
@@ -215,7 +215,9 @@ async function launchApp(log, xboxOneAddress, username, password) {
       let xboxError = {};
       try {
         xboxError = JSON.parse(error.body);
-      } catch (jsonError) {} // ignored
+      } catch (jsonError) {
+        // JSON parsing errors are ignored.
+      }
 
       if (xboxError.ErrorCode == ERROR_INSTALL_REGISTRATION_FAILURE) {
         log.error('Launch failure (ERROR_INSTALL_REGISTRATION_FAILURE).');
@@ -345,7 +347,7 @@ function httpRequestHelper(
 /**
  * Delay for a fixed number of seconds.
  *
- * @param {number} seconds
+ * @param {number} seconds The amount of time to delay
  * @return {!Promise}
  */
 function delay(seconds) {

--- a/backends/xboxone/xbox-one-webdriver-server.js
+++ b/backends/xboxone/xbox-one-webdriver-server.js
@@ -41,8 +41,13 @@ class XboxOneWebDriverServer extends GenericSingleSessionWebDriverServer {
 
   /** @override */
   async closeSingleSession() {
-    // Send the device back to the home screen.
-    await loadOnXboxOne(this.flags, this.log, null);
+    this.log.debug('Close requested.');
+    try {
+      await loadOnXboxOne(this.flags, this.log, null);
+    } catch (error) {
+      this.log.error('Error closing session\n', error);
+    }
+    this.log.debug('Close complete.');
   }
 
   /** @override */


### PR DESCRIPTION
This fixes several issues with reliability, especially when running
tests in a loop back-to-back without a delay between.  In those cases,
the Xbox One would frequently fail to launch or to uninstall the app.

Specific changes:

 - Await session closure on shutdown (fixed in base package v1.1.4)
 - Log but swallow app uninstall errors (don't report to the client)
 - Retry when app launch fails (after a delay to let Xbox recover)

Closes #44