### PR TITLE
feat: Instruct Chromecasts to show their serial numbers

### DIFF
--- a/backends/chromecast/chromecast-webdriver-cli.js
+++ b/backends/chromecast/chromecast-webdriver-cli.js
@@ -17,30 +17,39 @@
 
 
 const yargs = require('yargs');
-const {cast, addChromecastArgs} = require('./cast-utils');
+const {Mode, cast, addChromecastArgs} = require('./cast-utils');
 
 yargs
     .strict()
     .usage('Usage: $0 --hostname=<HOSTNAME> --url=<URL>')
-    .usage('   or: $0 --hostname=<HOSTNAME> --home')
+    .usage('-or-:  $0 --hostname=<HOSTNAME> --home')
+    .usage('-or-:  $0 --hostname=<HOSTNAME> --show-serial')
     .option('url', {
       description:
           'A URL to direct the Chromecast to.\n' +
-          'Either --url or --home must be specified.',
+          'Either --url, --home, or --show-serial must be specified.',
       type: 'string',
     })
     .option('home', {
       description:
           'Direct the Chromecast to the home screen.\n' +
-          'Either --url or --home must be specified.',
+          'Either --url, --home, or --show-serial must be specified.',
+      type: 'boolean',
+    })
+    .option('show-serial', {
+      description:
+          'Show the serial number of the Chromecast on the screen\n' +
+          'and speak it aloud (useful for audio-only devices).\n' +
+          'Either --url, --home, or --show-serial must be specified.',
       type: 'boolean',
     })
     // You can't use both at once.
-    .conflicts('url', 'home')
+    .conflicts('url', 'home', 'show-serial')
     .check((flags) => {
-      // Enforce that one or the other is specified.
-      if (!flags.url && !flags.home) {
-        throw new Error('Either --url or --home must be specified.');
+      // Enforce that one mode is required.
+      if (!flags.url && !flags.home && !flags.showSerial) {
+        throw new Error(
+            'Either --url, --home, or --show-serial must be specified.');
       }
 
       return true;
@@ -50,4 +59,11 @@ addChromecastArgs(yargs);
 
 const flags = yargs.argv;
 
-cast(flags, /* log= */ console, flags.url);
+let mode = Mode.HOME;
+if (flags.url) {
+  mode = Mode.URL;
+} else if (flags.showSerial) {
+  mode = Mode.SERIAL_NUMBER;
+}
+
+cast(flags, /* log= */ console, mode, flags.url);

--- a/backends/chromecast/chromecast-webdriver-server.js
+++ b/backends/chromecast/chromecast-webdriver-server.js
@@ -20,7 +20,7 @@ const {
   yargs,
 } = require('generic-webdriver-server');
 
-const {cast, addChromecastArgs} = require('./cast-utils');
+const {Mode, cast, addChromecastArgs} = require('./cast-utils');
 
 /** WebDriver server backend for Chromecast */
 class ChromecastWebDriverServer extends GenericSingleSessionWebDriverServer {
@@ -30,13 +30,13 @@ class ChromecastWebDriverServer extends GenericSingleSessionWebDriverServer {
 
   /** @override */
   async navigateToSingleSession(url) {
-    await cast(this.flags, this.log, url);
+    await cast(this.flags, this.log, Mode.URL, url);
   }
 
   /** @override */
   async closeSingleSession() {
     // Send the device back to the home screen.
-    await cast(this.flags, this.log, null);
+    await cast(this.flags, this.log, Mode.HOME);
   }
 }
 


### PR DESCRIPTION
This adds the --show-serial flag to the Chromecast CLI tool, to instruct Chromecast devices to show their serial numbers and read them aloud.