### PR TITLE
fix: Override allstar settings for binaries

### DIFF
--- a/.allstar/binary_artifacts.yaml
+++ b/.allstar/binary_artifacts.yaml
@@ -1,0 +1,8 @@
+# These are static binary dependencies used to build our Java jar.  They do not
+# change (since Selenium v3 is no longer in development), and are taken
+# directly from Selenium.  base/java/third_party/SOURCES.txt documents their
+# origin and license.
+ignorePaths:
+ - base/java/third_party/selenium-server-standalone-3.141.59.jar
+ - base/java/third_party/auto-common-0.8.jar
+ - base/java/third_party/auto-service-1.0-rc4.jar

--- a/base/java/third_party/SOURCES.txt
+++ b/base/java/third_party/SOURCES.txt
@@ -2,3 +2,18 @@ These third-party JARs were sourced from Selenium:
  - https://github.com/SeleniumHQ/selenium/tree/selenium-3.141.59/third_party/java/auto
  - https://github.com/SeleniumHQ/selenium/tree/selenium-3.141.59/third_party/java/service
  - https://selenium-release.storage.googleapis.com/3.141/selenium-server-standalone-3.141.59.jar
+
+
+Copyright 2018 Software Freedom Conservancy (SFC)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
We include three binary jars in this repository.  This asks allstar (Google scanning tool) to allow this.

Closes #67