### PR TITLE
fix(chromecast): Speed up shutdown

### DIFF
--- a/backends/chromecast/cast-utils.js
+++ b/backends/chromecast/cast-utils.js
@@ -125,12 +125,14 @@ function cast(flags, log, mode, url) {
           // The request was fulfilled.
           log.info('Cast successful.');
           clearTimeout(connectionTimer);
+          client.close();
           resolve();
         } else if (request.type == 'STOP' &&
             appIds.includes(HOME_SCREEN_APP_ID)) {
           // The home screen is showing.
           log.info('Return to home screen successful.');
           clearTimeout(connectionTimer);
+          client.close();
           resolve();
         } else if (data.type == 'LAUNCH_ERROR') {
           const message = 'Failed to launch receiver!  Reason: ' + data.reason;


### PR DESCRIPTION
After we launch the requested receiver app, we should shut down the connection explicitly.  Otherwise, the socket has to time out before the calling application in nodejs can terminate.  This is because nodejs keeps the main thread running so long as anything async could occur, including events on handles and sockets.