### PR TITLE
feat(chromecast): Allow async access to `cast.__platform__` via postMessage

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,9 @@ jobs:
       matrix:
         # Oldest supported LTS version through current LTS
         node-version: [12.x, 14.x, 16.x]
-        os: [macOS-latest, windows-latest, ubuntu-latest]
+        # NOTE: Old versions aren't available for mac-arm64, so we use macos-13
+        # (the last CI image based on x64 hardware)
+        os: [macos-13, windows-latest, ubuntu-latest]
       fail-fast: false
 
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,12 +22,18 @@ jobs:
         run: git config --global core.autocrlf false
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+
+      # Default Java on macos-13 seems to have an issue with building our jar
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: 11
 
       - name: Install deps
         shell: bash

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,6 +33,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
+          distribution: zulu
           java-version: 11
 
       - name: Install deps

--- a/backends/chromecast/receiver.html
+++ b/backends/chromecast/receiver.html
@@ -37,6 +37,44 @@ iframe {
     </style>
     <script>
 
+// Expose cast.__platform__ asynchronously through postMessage.
+// Cannot be used to proxy synchronous calls, but could be used for debugging
+// or with an async shim and `await` on all calls from the client.
+window.addEventListener('message', (event) => {
+  const data = event.data;
+  console.log('Top window received message:', data);
+
+  if (data.type == 'cast.__platform__') {
+    const platform = cast.__platform__;
+    const command = platform[data.command];
+
+    const args = data.args;
+    try {
+      const result = command.apply(platform, args);
+
+      const message = {
+        id: data.id,
+        type: data.type + ':result',
+        result: result,
+      };
+
+      console.log('Top window sending result:', message);
+      event.source.postMessage(message, '*');
+    } catch (error) {
+      console.log('Failed:', error);
+
+      const message = {
+        id: data.id,
+        type: data.type + ':error',
+        error: error.message,
+      };
+
+      console.log('Top window sending error:', message);
+      event.source.postMessage(message, '*');
+    }
+  }
+});
+
 window.addEventListener('DOMContentLoaded', () => {
   // Ignore the leading '?'.  The rest is the URL.
   const frameUrl = (location.search + location.hash).substr(1);


### PR DESCRIPTION
Expose `cast.__platform__` asynchronously through postMessage. Cannot be used to proxy synchronous calls, but could be used for debugging or with an async shim and `await` on all calls from the client.