### PR TITLE
fix(chromeos): Fix node-ssh exit code interpretation

### DIFF
--- a/backends/chromeos/chromeos-utils.js
+++ b/backends/chromeos/chromeos-utils.js
@@ -204,7 +204,8 @@ async function executeRemoteCommand(log, ssh, argv) {
   const output = await ssh.exec(executable, args, options);
 
   // output.code == 0 or output.code == null means success.
-  if (output.code != 0 && output.code != null) {
+  const success = output.code == 0 || output.code == null;
+  if (!success) {
     log.error(`Remote command ${argv.join(' ')} ` +
               `failed with exit code ${output.code} ` +
               `and full output: ${output.stdout} ${output.stderr}`);

--- a/backends/chromeos/chromeos-utils.js
+++ b/backends/chromeos/chromeos-utils.js
@@ -203,8 +203,8 @@ async function executeRemoteCommand(log, ssh, argv) {
 
   const output = await ssh.exec(executable, args, options);
 
-  // output.code == 0 means success.
-  if (output.code != 0) {
+  // output.code == 0 or output.code == null means success.
+  if (output.code != 0 && output.code != null) {
     log.error(`Remote command ${argv.join(' ')} ` +
               `failed with exit code ${output.code} ` +
               `and full output: ${output.stdout} ${output.stderr}`);


### PR DESCRIPTION
Since upgrading node-ssh, we sometimes get an exit code of 0, other times an exit code of null.  This makes the tool more flexible in interpreting those codes.