### PR TITLE
feat(chromecast)!: Fork receiver app v1

### DIFF
--- a/backends/chromecast/receiver-v1.html
+++ b/backends/chromecast/receiver-v1.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<!--
+ Copyright 2020 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<html>
+  <head>
+    <title>Chromecast WebDriver Receiver v1</title>
+<!--
+
+This is an archived version of the receiver from v1 releases.
+In v2, we break compatibility and register a new default app ID that has new
+capabilities.
+
+This version only took a URL as a parameter, and could only host content in an
+iframe.  It is registered to receiver app ID B602D163, the v1 default app ID.
+
+-->
+    <script src="https://www.gstatic.com/cast/sdk/libs/caf_receiver/v3/cast_receiver_framework.js"></script>
+    <style>
+
+html, body, iframe {
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  margin: 0;
+  box-sizing: border-box;
+  background: white;
+}
+
+iframe {
+  border: none;
+}
+
+    </style>
+    <script>
+
+// Expose cast.__platform__ asynchronously through postMessage.
+// Cannot be used to proxy synchronous calls, but could be used for debugging
+// or with an async shim and `await` on all calls from the client.
+window.addEventListener('message', (event) => {
+  const data = event.data;
+  console.log('Top window received message:', data);
+
+  if (data.type == 'cast.__platform__') {
+    const platform = cast.__platform__;
+    const command = platform[data.command];
+
+    const args = data.args;
+    try {
+      const result = command.apply(platform, args);
+
+      const message = {
+        id: data.id,
+        type: data.type + ':result',
+        result: result,
+      };
+
+      console.log('Top window sending result:', message);
+      event.source.postMessage(message, '*');
+    } catch (error) {
+      console.log('Failed:', error);
+
+      const message = {
+        id: data.id,
+        type: data.type + ':error',
+        error: error.message,
+      };
+
+      console.log('Top window sending error:', message);
+      event.source.postMessage(message, '*');
+    }
+  }
+});
+
+window.addEventListener('DOMContentLoaded', () => {
+  // Ignore the leading '?'.  The rest is the URL.
+  const frameUrl = (location.search + location.hash).substr(1);
+
+  const statusText = 'URL: ' + frameUrl;
+
+  const context = cast.framework.CastReceiverContext.getInstance();
+  context.start({
+    statusText,
+    disableIdleTimeout: true,
+  });
+
+  // Some features must be explicitly allowed for an iframe.
+  // These are needed for media-related testing.
+  // See also: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy
+  const allowedFeatures = [
+    'autoplay',
+    'encrypted-media',
+    'fullscreen',
+    'picture-in-picture',
+    'sync-xhr',
+  ];
+
+  window.frame.allow = allowedFeatures.join('; ');
+  window.frame.src = frameUrl;
+});
+
+    </script>
+  </head>
+  <body>
+    <iframe id="frame"></iframe>
+  </body>
+</html>


### PR DESCRIPTION
To prepare for a v2 client and receiver app, this copies receiver.html (with some additional comments) to receiver-v1.html.  After merging this change, the registration for the v1 receiver app ID will be changed to point to receiver-v1.html.  This will free us to make breaking changes in receiver.html under a new app ID.

It is important for a smooth transition to make a copy of receiver.html first and not simply rename it, because there will be a transition period where some Chromecasts under test will still refer to the old URL.  This should be < 48 hours after merge.