### PR TITLE
feat(tizen)!: Migrate Google Container Registry to GitHub Container Registry

### DIFF
--- a/backends/tizen/README.md
+++ b/backends/tizen/README.md
@@ -18,7 +18,7 @@ are used by the server, you may want to pre-fetch the image you'll be using.
 This command will fetch the default image:
 
 ```sh
-docker pull gcr.io/generic-webdriver-server/tizen-studio-tv-3.0
+docker pull ghcr.io/shaka-project/tizen-studio-tv-3.0
 ```
 
 

--- a/backends/tizen/how-it-works.md
+++ b/backends/tizen/how-it-works.md
@@ -30,7 +30,7 @@ environment.
 
 We provide public Docker images containing a copy of Tizen Studio.  By default,
 Tizen WebDriver Server uses the image published at
-`gcr.io/generic-webdriver-server/tizen-studio-tv-3.0` to run Tizen Studio with
+`ghcr.io/shaka-project/tizen-studio-tv-3.0` to run Tizen Studio with
 the TV 3.0 SDK installed, but you can configure the server to use any arbitrary
 Docker image if you have your own.  See the option `tizen-studio-docker-image`.
 
@@ -46,10 +46,10 @@ If you don't have pre-existing Docker images for Tizen Studio, but you want to
 create a custom image anyway, you can base yours on ours.  We currently provide
 two images:
 
- - `gcr.io/generic-webdriver-server/tizen-studio`: A base image with Tizen
+ - `ghcr.io/shaka-project/tizen-studio`: A base image with Tizen
    Studio installed on top of a minimal Ubuntu environment, with no special
    SDKs installed.
- - `gcr.io/generic-webdriver-server/tizen-studio-tv-3.0`: Built on top of the
+ - `ghcr.io/shaka-project/tizen-studio-tv-3.0`: Built on top of the
    base image, and includes the TV 3.0 SDK.
 
 The source for these images can be found in

--- a/backends/tizen/tizen-studio-docker/README.md
+++ b/backends/tizen/tizen-studio-docker/README.md
@@ -21,9 +21,9 @@ The Docker images are built using these commands before publishing them to the
 
 ```sh
 # The base image, containing Tizen Studio.
-docker build -t gcr.io/generic-webdriver-server/tizen-studio base/
+docker build -t ghcr.io/shaka-project/tizen-studio base/
 # An extension of the base image which also contains the Tizen TV 3.0 SDK.
-docker build -t gcr.io/generic-webdriver-server/tizen-studio-tv-3.0 tv-3.0/
+docker build -t ghcr.io/shaka-project/tizen-studio-tv-3.0 tv-3.0/
 ```
 
 ## Interactive use of Tizen Studio tools
@@ -34,7 +34,7 @@ variable.  Tizen Studio is installed in `~/tizen-studio`.
 
 ```sh
 # To get a shell in the Tizen Studio Docker image:
-docker run -it gcr.io/generic-webdriver-server/tizen-studio-tv-3.0
+docker run -it ghcr.io/shaka-project/tizen-studio-tv-3.0
 ```
 
 
@@ -44,7 +44,7 @@ The `sdb` tool's `connect` command starts a daemon in the background, so running
 that command alone will not work:
 
 ```sh
-docker run gcr.io/generic-webdriver-server/tizen-studio-tv-3.0 sdb connect mytv
+docker run ghcr.io/shaka-project/tizen-studio-tv-3.0 sdb connect mytv
 ```
 
 After the connection is established, the Docker image will shut down, and the

--- a/backends/tizen/tizen-studio-docker/tv-3.0/Dockerfile
+++ b/backends/tizen/tizen-studio-docker/tv-3.0/Dockerfile
@@ -5,7 +5,7 @@
 # be painful to install and configure.
 
 # Build on top of the generic tizen-studio package.
-FROM gcr.io/generic-webdriver-server/tizen-studio
+FROM ghcr.io/shaka-project/tizen-studio
 
 MAINTAINER joeyparrish <joeyparrish@google.com>
 

--- a/backends/tizen/tizen-utils.js
+++ b/backends/tizen/tizen-utils.js
@@ -206,7 +206,7 @@ function addTizenArgs(yargs) {
             'For local Tizen Studio installations, use ' +
             '--local-tizen-studio.\n',
         type: 'string',
-        default: 'gcr.io/generic-webdriver-server/tizen-studio-tv-3.0:1.1.4',
+        default: 'ghcr.io/shaka-project/tizen-studio-tv-3.0:2.0.0',
       })
       .option('tizen-studio-path', {
         description:


### PR DESCRIPTION
Google Container Registry is imposing more painful restrictions on us, so we are migrating the Tizen Studio TV docker image from GCR to GHCR (GitHub Container Registry).  This should be simpler overall for an open source project hosted on GitHub, and should also work well for forks.

Because the older registry is being shut down, this is a breaking change, and the Tizen v1.x packages will be marked as deprecated.